### PR TITLE
BCB-1115 -> development

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biogeography",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "homepage": "/biogeography/",
   "private": true,
   "dependencies": {

--- a/src/AnalysisPackages/AnalysisPackage.js
+++ b/src/AnalysisPackages/AnalysisPackage.js
@@ -10,7 +10,8 @@ import "./AnalysisPackages.css"
 const withSharedAnalysisCharacteristics = (AnalysisPackage,
     layers,
     sb_properties,
-    sb_url) => {
+    sb_url,
+    disableMultipleLayers) => {
     class HOC extends React.Component {
         constructor(props) {
             super(props)
@@ -26,7 +27,8 @@ const withSharedAnalysisCharacteristics = (AnalysisPackage,
                 bapWindowOpen: false,
                 jsonWindowOpen: false,
                 layersOpen: true,
-                prettyJson: false
+                prettyJson: false,
+                disableMultipleLayers: disableMultipleLayers
             }
             this.initilized = false
             this.jsonData = null
@@ -218,6 +220,14 @@ const withSharedAnalysisCharacteristics = (AnalysisPackage,
         toggleLayer(layer) {
             if (!layer || layer.hideCheckbox) {
                 //if the checkbox isn't displayed we don't want to do anything when the user clicks the label
+                return
+            }
+            if (disableMultipleLayers) {
+                if (layer.checked) {
+                    this.turnOffLayer()
+                    return
+                }
+                this.turnOnLayer(layer)
                 return
             }
             if (layer.checked) {

--- a/src/AnalysisPackages/NVCSHierarchyByPixel.js
+++ b/src/AnalysisPackages/NVCSHierarchyByPixel.js
@@ -380,6 +380,6 @@ class NVCSHierarchyByPixelPackage extends React.Component {
     }
 
 }
-const NVCSHierarchyByPixel = withSharedAnalysisCharacteristics(NVCSHierarchyByPixelPackage, layers, sb_properties, SB_URL);
+const NVCSHierarchyByPixel = withSharedAnalysisCharacteristics(NVCSHierarchyByPixelPackage, layers, sb_properties, SB_URL, true);
 
 export default NVCSHierarchyByPixel;

--- a/src/AnalysisPackages/NVCSSummaryByRegion.js
+++ b/src/AnalysisPackages/NVCSSummaryByRegion.js
@@ -336,6 +336,6 @@ class NVCSSummaryByRegionPackage extends React.Component {
 
 
 }
-const NVCSSummaryByRegion = withSharedAnalysisCharacteristics(NVCSSummaryByRegionPackage, layers, sb_properties, SB_URL);
+const NVCSSummaryByRegion = withSharedAnalysisCharacteristics(NVCSSummaryByRegionPackage, layers, sb_properties, SB_URL, true);
 
 export default NVCSSummaryByRegion;


### PR DESCRIPTION
@bgotthold-usgs Not sure what you think about adding more parameters to `withSharedAnalysisCharacteristics`... Should we maybe add a config parameter with the necessary properties next time we need to pass data from an Analysis Package? Or do you have another idea?