### PR TITLE
don't show search results when moving the time slider by comparing the…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "biogeography",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "homepage": "/biogeography/",
   "private": true,
   "dependencies": {

--- a/src/AnalysisPackages/AnalysisPackage.js
+++ b/src/AnalysisPackages/AnalysisPackage.js
@@ -484,6 +484,7 @@ const withSharedAnalysisCharacteristics = (AnalysisPackage,
                                         <label htmlFor="prettyCheckbox">{"Pretty JSON "}  </label>
                                         <input checked={this.state.prettyJson}
                                             onChange={() => this.setState({ prettyJson: !this.state.prettyJson })}
+                                            onClick={() => this.setState({ prettyJson: !this.state.prettyJson })}
                                             type="checkbox" id="prettyCheckbox" name="prettyCheckbox" />
                                     </div>
                                     <div className="JSON-text-container">

--- a/src/App.js
+++ b/src/App.js
@@ -110,7 +110,7 @@ class App extends React.Component {
 
     getHash() {
         let state = {
-            feature: { id: this.state.feature.properties.feature_id },
+            feature: { feature_id: this.state.feature.properties.feature_id },
             basemap: this.state.basemap,
             timeSlider: { rangeYearMin: this.state.rangeYearMin, rangeYearMax: this.state.rangeYearMax, mapDisplayYear: this.state.mapDisplayYear },
             bap: { activeLayerTitle: this.state.analysisLayers && this.state.analysisLayers.length ? this.state.analysisLayers[0].title : '', priorityBap: this.state.priorityBap },
@@ -328,7 +328,7 @@ class App extends React.Component {
     }
 
     submitHandler(e) {
-        fetch(GET_FEATURE_API + e.id)
+        fetch(GET_FEATURE_API + e.feature_id)
             .then(res => res.json())
             .then(
                 (data) => {
@@ -384,7 +384,7 @@ class App extends React.Component {
             if (feature["feature_class"] === overlay.featureClass) {
                 i = results.length
                 this.submitHandler({
-                    id: feature.feature_id
+                    feature_id: feature.feature_id
                 })
             }
         }

--- a/src/LeftPanel/LeftPanel.js
+++ b/src/LeftPanel/LeftPanel.js
@@ -167,6 +167,7 @@ class LeftPanel extends React.Component {
                         textSearchHandler={this.props.textSearchHandler}
                         submitHandler={this.props.submitHandler}
                         mapClicked={this.props.mapClicked}
+                        point={this.props.point}
                         enabledLayers={this.state.enabledLayers}
                         bioscape={this.state.bioscape}
                         overlayChanged={this.props.overlayChanged}

--- a/src/LeftPanel/searchBar/searchBar.js
+++ b/src/LeftPanel/searchBar/searchBar.js
@@ -22,7 +22,6 @@ class SearchBar extends React.Component {
         this.handleKeyUp = this.handleKeyUp.bind(this);
         this.onFocus = this.onFocus.bind(this)
         this.onBlur = this.onBlur.bind(this)
-        this.submit = this.submit.bind(this)
         this.toggleBasemapDropdown = this.toggleBasemapDropdown.bind(this)
         this.basemapChanged = this.basemapChanged.bind(this)
         this.textInput = ""
@@ -37,8 +36,10 @@ class SearchBar extends React.Component {
         document.body.removeEventListener('keydown', () => { this.setState({ displayHelp: false }) }, true);
     }
 
-    componentWillReceiveProps(props) {
-        if (props.mapClicked) {
+    componentDidUpdate(prevProps, prevState, snapshot) {
+        if (this.props.mapClicked
+            && this.props.point.lat !== prevProps.point.lat
+            && this.props.point.lng !== prevProps.point.lng) {
             this.textInput.focus();
             this.setState({
                 focused: true
@@ -67,10 +68,6 @@ class SearchBar extends React.Component {
         }, 150)
     }
 
-    submit(e) {
-        this.props.submitHandler(e)
-    }
-
 
     toggleBasemapDropdown() {
         this.setState({ layersDropdownOpen: !this.state.layersDropdownOpen });
@@ -79,18 +76,16 @@ class SearchBar extends React.Component {
     basemapChanged(e) {
         // Fixes bug in FF where search bar gains focus
         this.setState({ focused: false })
-
         this.props.basemapChanged(e)
     }
 
     render() {
-        let that = this;
         return (
             <div>
                 <div className="nbm-flex-row">
                     <div className="settings-btn-group nbm-flex-column">
                         <Button id={"SettingsTooltip"} onClick={this.toggleBasemapDropdown} className='submit-analysis-btn placeholder-button' >
-                            <Glyphicon className="inner-glyph" glyph="menu-hamburger"/>
+                            <Glyphicon className="inner-glyph" glyph="menu-hamburger" />
                         </Button>
                         <CustomToolTip target={`SettingsTooltip`} text="Settings" placement="right" ></CustomToolTip>
                     </div>
@@ -99,7 +94,6 @@ class SearchBar extends React.Component {
                             enabledLayers={this.props.enabledLayers}
                         />
                     </div>
-                    {/* {!this.props.bioscape.overlays && */}
                     {
                         <div className="nbm-flex-column-big">
                             {
@@ -113,10 +107,10 @@ class SearchBar extends React.Component {
                 <div className="nbm-flex-row" >
                     <div className="button-group" style={this.props.results.length > 0 && this.state.focused ? {} : { height: '0px' }}>
                         {(this.props.results.length > 0 && this.state.focused) ? <ButtonGroup vertical>
-                            {this.props.results.map(function (d, idx) {
+                            {this.props.results.map((d, idx) => {
                                 return (
                                     <Button className="sfr-button" style={{ whiteSpace: 'normal' }}
-                                        onClick={function () { that.submit(this) }}
+                                        onClick={() => { this.props.submitHandler(d) }}
                                         id={d.feature_id}
                                         key={d.feature_id}>
                                         {d.feature_name}{d.state ? ", " + d.state.name : ""} ({d.feature_class})
@@ -137,19 +131,6 @@ class SearchBar extends React.Component {
                                 />
                             </CardBody>
                         </Card>
-                        {/* Terrestrial had overlays section. comment for now, may remove layer if this change sticks */}
-                        {/* {this.props.bioscape.overlays &&
-                            <Card>
-                                <span className="header">Overlays</span>
-                                <CardBody>
-                                    <RadioGroup style={{ width: "100%" }}
-                                        options={this.props.bioscape.overlays}
-                                        onChange={this.props.overlayChanged}
-                                        canDeselect={true}
-                                    />
-                                </CardBody>
-                            </Card>
-                        } */}
                     </Collapse>
                 </div>
 


### PR DESCRIPTION
… point clicked to previous point. Also update search handler to use feature id instead of id to be more consistent with how we handle features