### PR TITLE
ci: make node image customizable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-# .gitlab-ci.yml
+# .gitlab-ci.yml for USGS SAS deployment
 #
 # This builds a Docker image and tags it as the latest for its branch.
 # After building, it will trigger a deployment pipeline in another repo.
@@ -43,9 +43,13 @@ stages:
 variables:
   # This is passed to deployment
   NBM_IMAGE: ${CI_REGISTRY}/${CI_PROJECT_NAMESPACE}/${CI_PROJECT_NAME}
-  # This is passed to deployment
   NBM_IMAGE_TAG: ${CI_COMMIT_REF_NAME}-${CI_COMMIT_SHORT_SHA}
+  node_image: code.chs.usgs.gov:5001/sas/ops/docker/base-images/node
+  node_image_tag: 10.15-latest
   DOCKERFILE: ./Dockerfile.static
+  DOCKER_BUILD_ARGS: >-
+    --build-arg node_image=${node_image}
+    --build-arg node_image_tag=${node_image_tag}
 
 trigger_deploy_development:
   extends: .deploy_trigger

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,5 +1,13 @@
+# Dockerfile for deploying the static site in a container
+
+ARG node_image=node
+ARG node_image_tag=10.15
+
+#
+# Build image
+#
 # base image
-FROM node:10.15 as npmbuild
+FROM ${node_image}:${node_image_tag} as npmbuild
 
 # set working directory
 RUN mkdir /usr/src/app
@@ -19,6 +27,11 @@ COPY public /usr/src/app/public
 COPY src /usr/src/app/src
 RUN npm run build
 
-FROM nginx:stable
+ARG nginx_image=nginx
+ARG nginx_image_tag=stable
+#
+# Runtime image
+#
+FROM ${nginx_image}:${nginx_image_tag}
 COPY --from=npmbuild /usr/src/app/build /usr/share/nginx/html/biogeography
 COPY conf/nginx.default.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
* Expose the images used in the 'static' build as build arguments - node
image and nginx image
* Use internal images in the .gitlab-ci file